### PR TITLE
Revise bucket LB resource names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ locals {
   lb_additional_cert_ids = [for cert_name in var.lb_ssl_certs : format(
     "projects/%s/global/sslCertificates/%s", data.google_client_config.google_client.project, cert_name
   )]
+  lb_ip_name = coalesce(var.lb_ip_name, "bucket-lbip") # for backward-compatibility only
 }
 
 data "google_client_config" "google_client" {}
@@ -107,7 +108,7 @@ resource "google_compute_target_https_proxy" "https_proxy" {
 
 resource "google_compute_global_address" "lb_ip" {
   count        = local.create_bucket_lb ? 1 : 0
-  name         = format("lb-ip-%s", local.lb_resource_name_suffix)
+  name         = format("${local.lb_ip_name}-%s", local.lb_resource_name_suffix)
   ip_version   = "IPV4"
   address_type = "EXTERNAL"
 }

--- a/main.tf
+++ b/main.tf
@@ -80,25 +80,25 @@ resource "google_storage_bucket_iam_member" "object_admins" {
 
 resource "google_compute_backend_bucket" "bucket_backend" {
   count       = local.create_bucket_lb ? 1 : 0
-  name        = format("backend-bucket-%s", local.lb_resource_name_suffix)
+  name        = format("bucket-backend-%s", local.lb_resource_name_suffix)
   bucket_name = local.bucket_name
 }
 
 resource "google_compute_url_map" "url_map" {
   count           = local.create_bucket_lb ? 1 : 0
-  name            = format("lb-%s", local.lb_resource_name_suffix)
+  name            = format("bucket-lb-%s", local.lb_resource_name_suffix)
   default_service = google_compute_backend_bucket.bucket_backend.0.self_link
 }
 
 resource "google_compute_managed_ssl_certificate" "mcrt" {
   count = local.create_bucket_lb ? 1 : 0
-  name  = format("cert-%s", local.lb_resource_name_suffix)
+  name  = format("bucket-cert-%s", local.lb_resource_name_suffix)
   managed { domains = [local.bucket_name] }
 }
 
 resource "google_compute_target_https_proxy" "https_proxy" {
   count   = local.create_bucket_lb ? 1 : 0
-  name    = format("https-proxy-%s", local.lb_resource_name_suffix)
+  name    = format("bucket-proxy-%s", local.lb_resource_name_suffix)
   url_map = google_compute_url_map.url_map.0.self_link
   ssl_certificates = distinct(concat(
     [google_compute_managed_ssl_certificate.mcrt.0.id], local.lb_additional_cert_ids
@@ -114,7 +114,7 @@ resource "google_compute_global_address" "lb_ip" {
 
 resource "google_compute_global_forwarding_rule" "fw_rule" {
   count      = local.create_bucket_lb ? 1 : 0
-  name       = format("forwarding-rule-%s", local.lb_resource_name_suffix)
+  name       = format("bucket-forwarding-rule-%s", local.lb_resource_name_suffix)
   target     = google_compute_target_https_proxy.https_proxy.0.self_link
   ip_address = google_compute_global_address.lb_ip.0.address
   port_range = "443"

--- a/variables.tf
+++ b/variables.tf
@@ -88,3 +88,9 @@ variable "lb_ssl_certs" {
   type        = list(string)
   default     = []
 }
+
+variable "lb_ip_name" {
+  description = "Name of the static external IP that is created for the load-balancer. For backward-compatibility only. Not recommended for general use. Will be used only if \"var.create_bucket_lb\" is \"true\"."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
These changes will destroy and recreate the LB resources.

However, these changes are contained within the infra and will not impact any externals consuming them. It will help us better organize and identify our bucket LB resources in the GCP console.

Only component impacting externals is the lb_ip for which we are providing a backward compatible way to avoid any service disruption.