### PR TITLE
Add config to allow new life cycle policy conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,43 @@ This upgrade will rename the load-balancer resource(s) for them to be coherently
 # Upgrade guide from v2.0.1 to v2.1.0
 
 First make sure you've planned & applied `v2.0.1`. Then, upon upgrading from `v2.0.1` to `v2.1.0`, you may (or may not) see a plan that destroys & creates an equal number of `google_storage_bucket_iam_member` resources. It is OK to apply these changes as it will only change the data-structure of these resources [from an array to a hashmap](https://github.com/airasia/terraform-google-external_access/wiki/The-problem-of-%22shifting-all-items%22-in-an-array). Note that, after you plan & apply these changes, you may (or may not) get a **"Provider produced inconsistent result after apply"** error. Just re-plan and re-apply and that would resolve the error.
+
+## Lifecycle Rules
+
+The `lifecycle_rules` variable allows you to configure object lifecycle management policies for the GCS bucket. This enables automatic deletion or storage class transitions based on various conditions.
+
+### Structure
+```hcl
+lifecycle_rules = [
+  {
+    action = {
+      type          = string  # Required: "Delete" or "SetStorageClass"
+      storage_class = string  # Optional: Required only when type is "SetStorageClass"
+                             # Valid values: "STANDARD", "NEARLINE", "COLDLINE", "ARCHIVE"
+    }
+    condition = {
+      # Age-based conditions
+      age                        = number  # Optional: Age of object in days
+      created_before             = string  # Optional: Date in RFC 3339 format (e.g., "2024-01-15")
+      
+      # Version-based conditions
+      with_state                 = string  # Optional: "LIVE", "ARCHIVED", or "ANY"
+      num_newer_versions         = number  # Optional: Number of newer versions to keep
+      
+      # Time-based conditions
+      custom_time_before         = string  # Optional: Date in RFC 3339 format
+      days_since_custom_time     = number  # Optional: Days since custom time
+      days_since_noncurrent_time = number  # Optional: Days since object became noncurrent
+      noncurrent_time_before     = string  # Optional: Date in RFC 3339 format
+      
+      # Prefix/Suffix matching (accepts list of strings)
+      matches_prefix             = list(string)  # Optional: List of object name prefixes to match
+      matches_suffix             = list(string)  # Optional: List of object name suffixes to match
+      
+      # Storage class matching
+      matches_storage_class      = list(string)  # Optional: List of storage classes to match
+    }
+  }
+]
+```
+

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "google_project_service" "storage_api" {
 resource "google_storage_bucket" "gcs_bucket" {
   name                        = local.bucket_name
   location                    = local.bucket_location
-  storage_class               = var.storage_class 
+  storage_class               = var.storage_class
   labels                      = local.bucket_labels
   uniform_bucket_level_access = local.uniform_access
   force_destroy               = false
@@ -58,8 +58,14 @@ resource "google_storage_bucket" "gcs_bucket" {
         matches_storage_class = contains(keys(lifecycle_rule.value.condition), "matches_storage_class") ? (
           split(",", lifecycle_rule.value.condition["matches_storage_class"])
         ) : null
-        num_newer_versions = lookup(lifecycle_rule.value.condition, "num_newer_versions", null)
+        matches_prefix             = lookup(lifecycle_rule.value.condition, "matches_prefix", null)
+        matches_suffix             = lookup(lifecycle_rule.value.condition, "matches_suffix", null)
+        num_newer_versions         = lookup(lifecycle_rule.value.condition, "num_newer_versions", null)
+        custom_time_before         = lookup(lifecycle_rule.value.condition, "custom_time_before", null)
+        days_since_custom_time     = lookup(lifecycle_rule.value.condition, "days_since_custom_time", null)
         days_since_noncurrent_time = lookup(lifecycle_rule.value.condition, "days_since_noncurrent_time", null)
+        noncurrent_time_before     = lookup(lifecycle_rule.value.condition, "noncurrent_time_before", null)
+
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,6 @@ resource "google_storage_bucket" "gcs_bucket" {
         days_since_custom_time     = lookup(lifecycle_rule.value.condition, "days_since_custom_time", null)
         days_since_noncurrent_time = lookup(lifecycle_rule.value.condition, "days_since_noncurrent_time", null)
         noncurrent_time_before     = lookup(lifecycle_rule.value.condition, "noncurrent_time_before", null)
-
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -82,11 +82,8 @@ variable "labels" {
 
 variable "lifecycle_rules" {
   description = "List of lifecycle rules to configure. Accepts action.type, action.storage_class, condition.age, condition.created_before, condition.with_state, condition.matches_storage_class, condition.num_newer_versions. Format is same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule. Except condition.matches_storage_class should be a comma delimited string."
-  type = set(object({
-    action    = map(string)
-    condition = map(string)
-  }))
-  default = []
+  type        = any
+  default     = []
 }
 
 variable "lb_ssl_certs" {


### PR DESCRIPTION
Description

Added support for matches_prefix and matches_suffix in lifecycle rule conditions.

Updated dynamic "lifecycle_rule" block to align with Google provider v4.85.0.

Replaced deprecated prefix field with matches_prefix.

https://registry.terraform.io/providers/hashicorp/google/4.85.0/docs/resources/storage_bucket#nested_condition